### PR TITLE
Simplify functions

### DIFF
--- a/debris/core/src/function_interface.rs
+++ b/debris/core/src/function_interface.rs
@@ -101,7 +101,7 @@ where
     T: ObjectPayload,
 {
     fn into_result(self, ctx: &mut FunctionContext) -> LangResult<ObjectRef> {
-        Ok(self.into_object(ctx.compile_context))
+        Ok(self.into_object(ctx.compile_context()))
     }
 
     fn get_class(ctx: &CompileContext) -> Option<GenericClassRef> {
@@ -114,7 +114,7 @@ where
     T: ObjectPayload,
 {
     fn into_result(self, ctx: &mut FunctionContext) -> LangResult<ObjectRef> {
-        self.map(|value| value.into_object(ctx.compile_context))
+        self.map(|value| value.into_object(ctx.compile_context()))
     }
 
     fn get_class(ctx: &CompileContext) -> Option<GenericClassRef> {
@@ -147,7 +147,7 @@ macro_rules! impl_map_valid_return_type {
     ($from:ty, $to:ty) => {
         impl ValidReturnType for $from {
             fn into_result(self, ctx: &mut FunctionContext) -> LangResult<ObjectRef> {
-                Ok(<$to as From<$from>>::from(self).into_object(ctx.compile_context))
+                Ok(<$to as From<$from>>::from(self).into_object(ctx.compile_context()))
             }
 
             fn get_class(ctx: &CompileContext) -> Option<GenericClassRef> {
@@ -181,7 +181,7 @@ where
 }
 
 /// For functions of the format Fn(ctx, objects) -> ValidReturn
-impl<F, R> ToFunctionInterface<(&mut FunctionContext<'_, '_, '_>, &[ObjectRef]), R> for F
+impl<F, R> ToFunctionInterface<(&mut FunctionContext<'_, '_, '_, '_>, &[ObjectRef]), R> for F
 where
     F: Fn(&mut FunctionContext, &[ObjectRef]) -> R + 'static,
     R: ValidReturnType,
@@ -201,7 +201,7 @@ where
 macro_rules! impl_to_function_interface {
     ($($xs:ident),*) => {
         /// With mut function context
-        impl<Function, Return, $($xs),*> ToFunctionInterface<(&mut FunctionContext<'_, '_, '_>, $(&$xs),*), Return> for Function
+        impl<Function, Return, $($xs),*> ToFunctionInterface<(&mut FunctionContext<'_, '_, '_, '_>, $(&$xs),*), Return> for Function
         where
             Function: Fn(&mut FunctionContext, $(&$xs),*) -> Return + 'static,
             Return: ValidReturnType,
@@ -227,7 +227,7 @@ macro_rules! impl_to_function_interface {
         }
 
         /// With non-mut function context
-        impl<Function, Return, $($xs),*> ToFunctionInterface<(&FunctionContext<'_, '_, '_>, $(&$xs),*), Return> for Function
+        impl<Function, Return, $($xs),*> ToFunctionInterface<(&FunctionContext<'_, '_, '_, '_>, $(&$xs),*), Return> for Function
         where
             Function: Fn(&FunctionContext, $(&$xs),*) -> Return + 'static,
             Return: ValidReturnType,

--- a/debris/core/src/llir/llir_builder.rs
+++ b/debris/core/src/llir/llir_builder.rs
@@ -168,7 +168,7 @@ impl MirVisitor for LlirBuilder<'_, '_, '_> {
                 nodes: &mut self.nodes,
                 item_id: return_id,
                 namespaces: self.arena,
-                parent: self.context.context_id,
+                llir_context: &self.context,
             },
             &parameters,
         )?;

--- a/debris/core/src/llir/llir_builder.rs
+++ b/debris/core/src/llir/llir_builder.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::Result,
-    memory::mem_move,
+    memory::mem_copy,
     mir::{
         ContextId, MirBranchIf, MirCall, MirContext, MirContextMap, MirGotoContext,
         MirJumpLocation, MirReturnValue, MirUpdateValue, MirValue, MirVisitor, NamespaceArena,
@@ -216,7 +216,7 @@ impl MirVisitor for LlirBuilder<'_, '_, '_> {
         let old_value = self.get_object_by_id(update_value.id);
 
         if let Some(old_value) = old_value {
-            mem_move(|node| self.emit(node), &old_value, &new_value);
+            mem_copy(|node| self.emit(node), &old_value, &new_value);
 
             // if the value is comptime, override the old value
             if !old_value.class.typ().runtime_encodable() {
@@ -246,7 +246,7 @@ impl MirVisitor for LlirBuilder<'_, '_, '_> {
 
         if let Some(target_object) = target_object {
             // Copy the returned object to the common memory address
-            mem_move(|node| self.emit(node), &target_object, &object);
+            mem_copy(|node| self.emit(node), &target_object, &object);
         } else {
             // Set the target object
             self.set_object(object, template.template().unwrap().1);
@@ -276,7 +276,7 @@ impl MirVisitor for LlirBuilder<'_, '_, '_> {
                 let function = self.llir_helper.get_function(&id).unwrap();
 
                 // Copy the neg_branch value to the pos_branch, so that both paths are valid
-                mem_move(|node| function.nodes.push(node), &pos_result, &neg_result);
+                mem_copy(|node| function.nodes.push(node), &pos_result, &neg_result);
 
                 id
             };

--- a/debris/core/src/llir/llir_builder.rs
+++ b/debris/core/src/llir/llir_builder.rs
@@ -41,7 +41,7 @@ impl<'ctx, 'arena, 'llir> LlirBuilder<'llir, 'ctx, 'arena> {
             compile_context: context.compile_context,
             context_id: context.id,
         };
-        
+
         let current_block_index = 0;
         let id = llir_helper.block_for((context.id, current_block_index));
         LlirBuilder {
@@ -162,7 +162,7 @@ impl MirVisitor for LlirBuilder<'_, '_, '_> {
             &mut FunctionContext {
                 span: call.span,
                 item_id: return_id,
-                llir_builder: self
+                llir_builder: self,
             },
             &parameters,
         )?;

--- a/debris/core/src/llir/llir_context.rs
+++ b/debris/core/src/llir/llir_context.rs
@@ -14,7 +14,7 @@ use super::utils::ItemId;
 /// Similar to mir contexts, but a bit simpler.
 /// Borrows MirNodes from an actual MirContext.
 #[derive(Debug)]
-pub(crate) struct LlirContext<'ctx> {
+pub struct LlirContext<'ctx> {
     pub span: Span,
     /// The previous mir nodes
     pub(crate) mir_nodes: &'ctx [MirNode],

--- a/debris/core/src/llir/llir_context.rs
+++ b/debris/core/src/llir/llir_context.rs
@@ -56,7 +56,6 @@ impl<'ctx> LlirContext<'ctx> {
         index: ItemId,
     ) {
         let context = contexts.get(index.context);
-
         let old_value = arena.replace_with_id(
             index.id,
             context.id.as_inner(),

--- a/debris/core/src/llir/llir_impl.rs
+++ b/debris/core/src/llir/llir_impl.rs
@@ -73,7 +73,8 @@ impl fmt::Display for Llir {
         let fmt_function = &|func: &Function, f: &mut fmt::Formatter<'_>| {
             f.write_fmt(format_args!(
                 "({} call(s)) - {}",
-                call_stats.get(&func.id).unwrap_or(&0), func
+                call_stats.get(&func.id).unwrap_or(&0),
+                func
             ))
         };
 
@@ -133,7 +134,8 @@ impl LlirFunctions {
 
     fn into_llir(self, config: &Config) -> Llir {
         let main_function_id = self.main_function.expect("No main function");
-        let optimizer = GlobalOptimizer::new(config, &self.runtime, self.functions, main_function_id);
+        let optimizer =
+            GlobalOptimizer::new(config, &self.runtime, self.functions, main_function_id);
         let functions = optimizer
             .run()
             .into_iter()

--- a/debris/core/src/llir/llir_impl.rs
+++ b/debris/core/src/llir/llir_impl.rs
@@ -56,7 +56,11 @@ impl Llir {
         }
 
         for on_load_block in &self.runtime.load_blocks {
-            *stats.entry(*on_load_block).or_insert(0) += 1;
+            *stats.entry(*on_load_block).or_default() += 1;
+        }
+
+        for on_tick_block in &self.runtime.scheduled_blocks {
+            *stats.entry(*on_tick_block).or_default() += 1;
         }
 
         stats
@@ -69,7 +73,7 @@ impl fmt::Display for Llir {
         let fmt_function = &|func: &Function, f: &mut fmt::Formatter<'_>| {
             f.write_fmt(format_args!(
                 "({} call(s)) - {}",
-                call_stats[&func.id], func
+                call_stats.get(&func.id).unwrap_or(&0), func
             ))
         };
 
@@ -84,15 +88,15 @@ impl fmt::Display for Llir {
 
 /// A function node as it is represented during the llir stage
 #[derive(Debug)]
-pub(crate) struct LLirFunction {
-    pub(crate) returned_value: ObjectRef,
-    pub(crate) nodes: PeepholeOptimizer,
+pub struct LLirFunction {
+    pub returned_value: ObjectRef,
+    pub nodes: PeepholeOptimizer,
 }
 
 /// Contains the already generated llir functions and
 /// in the future potentialle other details
 #[derive(Debug, Default)]
-pub(crate) struct LlirFunctions {
+pub struct LlirFunctions {
     pub runtime: Runtime,
     pub functions: FxHashMap<BlockId, LLirFunction>,
     /// Mapping from context to function
@@ -129,7 +133,7 @@ impl LlirFunctions {
 
     fn into_llir(self, config: &Config) -> Llir {
         let main_function_id = self.main_function.expect("No main function");
-        let optimizer = GlobalOptimizer::new(config, self.functions, main_function_id);
+        let optimizer = GlobalOptimizer::new(config, &self.runtime, self.functions, main_function_id);
         let functions = optimizer
             .run()
             .into_iter()

--- a/debris/core/src/llir/mod.rs
+++ b/debris/core/src/llir/mod.rs
@@ -6,7 +6,7 @@
 //! ToDo: Example for Llir pseudo-code
 
 mod llir_context;
-pub(crate) use llir_context::LlirContext;
+pub use llir_context::LlirContext;
 
 mod llir_builder;
 pub(crate) use llir_builder::LlirBuilder;

--- a/debris/core/src/llir/opt/peephole_opt.rs
+++ b/debris/core/src/llir/opt/peephole_opt.rs
@@ -13,7 +13,7 @@ use super::variable_metadata::{Hint, ValueHints};
 /// A single `PeepholeOptimizer` can only be active in a single context
 /// (aka a single .mcfunction file)
 #[derive(Debug, Default)]
-pub(crate) struct PeepholeOptimizer {
+pub struct PeepholeOptimizer {
     nodes: Vec<Node>,
 
     /// Information about the possible values of runtime variables

--- a/debris/core/src/llir/utils.rs
+++ b/debris/core/src/llir/utils.rs
@@ -102,10 +102,6 @@ pub struct ItemId {
 
 impl fmt::Display for ItemId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_fmt(format_args!(
-            "{}.{}",
-            self.context,
-            self.id
-        ))
+        f.write_fmt(format_args!("{}.{}", self.context, self.id))
     }
 }

--- a/debris/core/src/llir/utils.rs
+++ b/debris/core/src/llir/utils.rs
@@ -104,7 +104,7 @@ impl fmt::Display for ItemId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_fmt(format_args!(
             "{}.{}",
-            self.context.as_inner().into_raw_parts().0,
+            self.context,
             self.id
         ))
     }

--- a/debris/core/src/memory.rs
+++ b/debris/core/src/memory.rs
@@ -18,7 +18,7 @@ pub fn copy(dest: ItemId, source: ItemId) -> Node {
 }
 
 /// Copies all items from source over to destination
-pub fn mem_move<F>(mut add_node: F, dest: &ObjectRef, source: &ObjectRef)
+pub fn mem_copy<F>(mut add_node: F, dest: &ObjectRef, source: &ObjectRef)
 where
     F: FnMut(Node),
 {

--- a/debris/core/src/mir/mir_builder.rs
+++ b/debris/core/src/mir/mir_builder.rs
@@ -17,7 +17,6 @@ use crate::{
     llir::utils::ItemId,
     objects::{
         obj_bool_static::ObjStaticBool,
-        obj_call::ObjCall,
         obj_class::{GenericClass, GenericClassRef, HasClass},
         obj_function::{FunctionParameters, ObjFunction},
         obj_int_static::ObjStaticInt,
@@ -1065,22 +1064,6 @@ impl<'a, 'ctx> MirBuilder<'a, 'ctx> {
             .into_object(self.compile_context),
             return_value,
         ))
-    }
-
-    /// Calls a function without any parameters.
-    /// This is used so that the blocks of such functions are already known at the mir stage.
-    /// For example, this allows passing functions without parameters to built-in functions.
-    fn call_parameterless_function(&mut self, function: ObjectRef, span: Span) -> Result<MirValue> {
-        // This span is just a technical detail so it should not matter that its length is 0
-        // It cannot be `span` because a span has to be a unique identifier for a given function
-        // (That context is a wrapper)
-        let context_id = self.add_context(Span::new(span.start(), 0), ContextKind::NativeFunction);
-        let function_result = self.call_function(function, None, Vec::new(), span)?;
-        self.pop_context();
-
-        let obj_call = ObjCall::new(self.compile_context, context_id, function_result);
-
-        Ok(MirValue::Concrete(obj_call.into_object(&self.compile_context)))
     }
 
     /// Tries to clone this value or returns the original value if it does not need to be cloned

--- a/debris/core/src/mir/mir_builder.rs
+++ b/debris/core/src/mir/mir_builder.rs
@@ -280,6 +280,8 @@ impl<'a> HirVisitor<'a> for MirBuilder<'a, '_> {
             .into_object(self.compile_context),
         );
 
+        
+
         let ident = self.context().get_ident(&function.ident);
 
         // Resolves the attributes of the function:

--- a/debris/core/src/mir/mir_builder.rs
+++ b/debris/core/src/mir/mir_builder.rs
@@ -56,7 +56,7 @@ pub struct MirBuilder<'a, 'ctx> {
     hir_modules: &'a [HirModule],
     /// Cache for all function definitions that were already visited
     visited_functions: HashMap<Span, Rc<CachedFunctionSignature>>,
-    function_blocks: Vec<&'a HirBlock>,
+    hir_function_blocks: Vec<&'a HirBlock>,
     /// The first visited function gets marked as the main function
     pub main_context: Option<ContextId>,
     /// The global, empty context which only contains modules
@@ -255,20 +255,20 @@ impl<'a> HirVisitor<'a> for MirBuilder<'a, '_> {
                     })
                     .collect::<Result<Vec<_>>>()?;
 
-                self.function_blocks.push(&function.block);
+                self.hir_function_blocks.push(&function.block);
                 self.visited_functions.insert(
                     function.span,
                     Rc::new(CachedFunctionSignature {
                         parameters,
                         return_type: result_pattern,
-                        block_id: self.function_blocks.len() - 1,
+                        block_id: self.hir_function_blocks.len() - 1,
                     }),
                 );
                 self.visited_functions.get(&function.span).unwrap()
             }
         };
 
-        let mut function_value = MirValue::Concrete(
+        let function_value = MirValue::Concrete(
             ObjNativeFunctionSignature::new(
                 self.compile_context,
                 self.compile_context.get_unique_id(),
@@ -282,61 +282,6 @@ impl<'a> HirVisitor<'a> for MirBuilder<'a, '_> {
         );
 
         let ident = self.context().get_ident(&function.ident);
-
-        // Resolves the attributes of the function:
-        // An attribute takes a function in and spits another function out.
-        // This allows for example to specify that a function should tick via an attribute.
-        // Attributes are evaluated in reverse order.
-        let attributes = function.attributes.iter().map(|attr| &attr.accessor);
-        for path in attributes.rev() {
-            let AccessedProperty { parent: _, value } = self.context_info().resolve_path(path)?;
-
-            let return_loc = self.context_mut().next_jump_location();
-            let parameters = vec![function_value];
-
-            let obj = value.concrete();
-            let sig = obj
-                .as_ref()
-                .and_then(|obj| obj.downcast_payload::<ObjNativeFunctionSignature>())
-                .ok_or_else(|| {
-                    LangError::new(
-                        LangErrorKind::UnexpectedType {
-                            expected: TypePattern::Class(
-                                ObjNativeFunctionSignature::class(self.compile_context)
-                                    .as_generic_ref(),
-                            ),
-                            got: value.class().clone(),
-                            declared: None,
-                        },
-                        path.span(),
-                    )
-                })?;
-
-            self.context_stack.push_jump_location(
-                ControlFlowMode::Return,
-                self.context().id,
-                return_loc,
-            );
-            let (func, new_func) =
-                self.instantiate_native_function(sig, &parameters, path.span())?;
-
-            let (_, call) =
-                self.context_info()
-                    .register_function_call(func, parameters, None, path.span())?;
-            self.push(call);
-
-            self.context_stack
-                .pop_jump_location(ControlFlowMode::Return);
-            self.push(MirNode::JumpLocation(MirJumpLocation { index: return_loc }));
-
-            function_value = new_func;
-        }
-
-        if matches!(function_value.class().get_generics("In"), Some([])) {
-            if let Some(function_obj) = function_value.concrete() {
-                function_value = self.call_parameterless_function(function_obj, function.span)?;
-            }
-        }
         // Add the final function to the namespace
         self.context_info()
             .add_value(ident, function_value, function.span)?;
@@ -785,7 +730,7 @@ impl<'a, 'ctx> MirBuilder<'a, 'ctx> {
             context_stack,
             hir_modules,
             visited_functions: HashMap::new(),
-            function_blocks: Vec::new(),
+            hir_function_blocks: Vec::new(),
             main_context: None,
             global_context: global_context_id,
         }
@@ -1081,7 +1026,7 @@ impl<'a, 'ctx> MirBuilder<'a, 'ctx> {
                 self.context_info()
                     .add_value(sig.name.clone(), parameter.clone(), sig.span)?;
             }
-            let result = self.visit_block_local(self.function_blocks[signature.block_id])?;
+            let result = self.visit_block_local(self.hir_function_blocks[signature.block_id])?;
 
             let (next_context, next_block) = self
                 .context_stack
@@ -1105,7 +1050,7 @@ impl<'a, 'ctx> MirBuilder<'a, 'ctx> {
                     expected: signature.return_type.clone(),
                     got: return_value.class().clone(),
                 },
-                self.function_blocks[signature.block_id].last_item_span(),
+                self.hir_function_blocks[signature.block_id].last_item_span(),
             )
             .into());
         }

--- a/debris/core/src/mir/mir_builder.rs
+++ b/debris/core/src/mir/mir_builder.rs
@@ -337,7 +337,6 @@ impl<'a> HirVisitor<'a> for MirBuilder<'a, '_> {
                 function_value = self.call_parameterless_function(function_obj, function.span)?;
             }
         }
-
         // Add the final function to the namespace
         self.context_info()
             .add_value(ident, function_value, function.span)?;

--- a/debris/core/src/mir/mir_context.rs
+++ b/debris/core/src/mir/mir_context.rs
@@ -1,7 +1,4 @@
-use std::{
-    iter,
-    ops::{Deref, DerefMut},
-};
+use std::{fmt, iter, ops::{Deref, DerefMut}};
 
 use debris_common::{Ident, Span};
 use generational_arena::{Arena, Index};
@@ -169,6 +166,12 @@ impl ContextId {
 impl From<Index> for ContextId {
     fn from(value: Index) -> Self {
         ContextId(value)
+    }
+}
+
+impl fmt::Display for ContextId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_inner().into_raw_parts().0)
     }
 }
 

--- a/debris/core/src/mir/mir_context.rs
+++ b/debris/core/src/mir/mir_context.rs
@@ -1,4 +1,7 @@
-use std::{fmt, iter, ops::{Deref, DerefMut}};
+use std::{
+    fmt, iter,
+    ops::{Deref, DerefMut},
+};
 
 use debris_common::{Ident, Span};
 use generational_arena::{Arena, Index};

--- a/debris/core/src/mir/mir_nodes.rs
+++ b/debris/core/src/mir/mir_nodes.rs
@@ -230,18 +230,12 @@ impl Eq for MirCall {}
 
 impl fmt::Display for MirNode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fn fmt_item_id(id: &ItemId) -> String {
-            format!("{}.{}", id.context.as_inner().into_raw_parts().0, id.id)
-        }
 
-        fn fmt_context(id: &ContextId) -> String {
-            format!("{}", id.as_inner().into_raw_parts().0)
-        }
 
         fn fmt_value(value: &MirValue) -> String {
             match value {
                 MirValue::Concrete(obj) => format!("{}", obj),
-                MirValue::Template { id, class } => format!("{}({})", fmt_item_id(id), class),
+                MirValue::Template { id, class } => format!("{}({})", id, class),
             }
         }
 
@@ -250,11 +244,11 @@ impl fmt::Display for MirNode {
                 "\t{} := if {}, {}({}), {}({})",
                 branch
                     .value_id
-                    .map_or_else(|| "_".to_string(), |id| fmt_item_id(&id)),
+                    .map_or_else(|| "_".to_string(), |id| id.to_string()),
                 fmt_value(&branch.condition),
-                fmt_context(&branch.pos_branch),
+                branch.pos_branch,
                 fmt_value(&branch.neg_value),
-                fmt_context(&branch.neg_branch),
+                branch.neg_branch,
                 fmt_value(&branch.neg_value)
             )),
             MirNode::Call(call) => f.write_fmt(format_args!(
@@ -268,18 +262,18 @@ impl fmt::Display for MirNode {
             )),
             MirNode::GotoContext(goto) => f.write_fmt(format_args!(
                 "\tgoto {}, {}",
-                fmt_context(&goto.context_id),
+                goto.context_id,
                 goto.block_id
             )),
             MirNode::JumpLocation(loc) => f.write_fmt(format_args!("\n.{}:", loc.index)),
             MirNode::ReturnValue(ret) => f.write_fmt(format_args!(
                 "\tset_ret {}, {}",
-                fmt_context(&ret.context_id),
+                ret.context_id,
                 ret.return_index
             )),
             MirNode::UpdateValue(update) => f.write_fmt(format_args!(
                 "\tupdate {}, {}",
-                fmt_item_id(&update.id),
+                update.id,
                 fmt_value(&update.new_value)
             )),
         }

--- a/debris/core/src/mir/mir_nodes.rs
+++ b/debris/core/src/mir/mir_nodes.rs
@@ -230,8 +230,6 @@ impl Eq for MirCall {}
 
 impl fmt::Display for MirNode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-
-
         fn fmt_value(value: &MirValue) -> String {
             match value {
                 MirValue::Concrete(obj) => format!("{}", obj),
@@ -262,14 +260,12 @@ impl fmt::Display for MirNode {
             )),
             MirNode::GotoContext(goto) => f.write_fmt(format_args!(
                 "\tgoto {}, {}",
-                goto.context_id,
-                goto.block_id
+                goto.context_id, goto.block_id
             )),
             MirNode::JumpLocation(loc) => f.write_fmt(format_args!("\n.{}:", loc.index)),
             MirNode::ReturnValue(ret) => f.write_fmt(format_args!(
                 "\tset_ret {}, {}",
-                ret.context_id,
-                ret.return_index
+                ret.context_id, ret.return_index
             )),
             MirNode::UpdateValue(update) => f.write_fmt(format_args!(
                 "\tupdate {}, {}",

--- a/debris/core/src/objects/mod.rs
+++ b/debris/core/src/objects/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod obj_bool;
 pub mod obj_bool_static;
+pub mod obj_call;
 pub mod obj_class;
 pub mod obj_function;
 pub mod obj_int;

--- a/debris/core/src/objects/obj_call.rs
+++ b/debris/core/src/objects/obj_call.rs
@@ -1,12 +1,12 @@
 use std::{fmt, rc::Rc};
 
 use crate::{
+    error::LangResult,
     llir::llir_nodes::{Call, Node},
     memory::MemoryLayout,
     mir::{ContextId, MirValue},
     objects::obj_function::{FunctionOverload, FunctionParameters, FunctionSignature},
-    CompileContext, ObjectPayload, ObjectRef, Type, 
-    error::LangResult
+    CompileContext, ObjectPayload, ObjectRef, Type,
 };
 use debris_derive::object;
 
@@ -27,6 +27,7 @@ impl ObjCall {
         let class = return_value.class().clone();
         let function = move |ctx: &mut FunctionContext, _: &[ObjectRef]| -> LangResult<ObjectRef> {
             let id = ctx.block_for(context_id);
+            println!("Hi");
             ctx.emit(Node::Call(Call { id }));
             Ok(ctx.get_object(&return_value))
         };

--- a/debris/core/src/objects/obj_call.rs
+++ b/debris/core/src/objects/obj_call.rs
@@ -1,0 +1,66 @@
+use std::{fmt, rc::Rc};
+
+use crate::{
+    llir::llir_nodes::{Call, Node},
+    memory::MemoryLayout,
+    mir::{ContextId, MirValue},
+    objects::obj_function::{FunctionOverload, FunctionParameters, FunctionSignature},
+    CompileContext, ObjectPayload, ObjectRef, Type, 
+    error::LangResult
+};
+use debris_derive::object;
+
+use super::obj_function::{FunctionContext, ObjFunction};
+
+/// A call behaves much like a native function, however it
+/// has no parameters and already a generated context.
+/// This allows builtin functions to work with `ObjCall`.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ObjCall {
+    pub context_id: ContextId,
+    function: ObjFunction,
+}
+
+#[object(Type::Function)]
+impl ObjCall {
+    pub fn new(ctx: &CompileContext, context_id: ContextId, return_value: MirValue) -> Self {
+        let class = return_value.class().clone();
+        let function = move |ctx: &mut FunctionContext, _: &[ObjectRef]| -> LangResult<ObjectRef> {
+            let id = ctx.block_for(context_id);
+            ctx.emit(Node::Call(Call { id }));
+            Ok(ctx.get_object(&return_value))
+        };
+
+        let debris_function = ObjFunction::new(
+            ctx,
+            vec![FunctionOverload::new(
+                Rc::new(FunctionSignature::new(
+                    FunctionParameters::Specific(vec![]),
+                    class,
+                )),
+                function.into(),
+            )],
+        );
+
+        ObjCall {
+            context_id,
+            function: debris_function,
+        }
+    }
+}
+
+impl ObjectPayload for ObjCall {
+    fn memory_layout(&self, _: &CompileContext) -> MemoryLayout {
+        MemoryLayout::Unsized
+    }
+
+    fn as_function(&self) -> Option<&ObjFunction> {
+        Some(&self.function)
+    }
+}
+
+impl fmt::Display for ObjCall {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Call({})", self.context_id)
+    }
+}

--- a/debris/core/src/objects/obj_native_function.rs
+++ b/debris/core/src/objects/obj_native_function.rs
@@ -6,10 +6,6 @@ use itertools::{EitherOrBoth, Itertools};
 
 use crate::{
     error::LangResult,
-    llir::{
-        llir_nodes::{Call, Node},
-        LlirBuilder,
-    },
     memory::MemoryLayout,
     mir::{CachedFunctionSignature, ContextId},
     types::TypePattern,
@@ -75,25 +71,30 @@ impl ObjNativeFunction {
         );
         let function =
             move |ctx: &mut FunctionContext, objects: &[ObjectRef]| -> LangResult<ObjectRef> {
-                let namespace = ctx.make_context();
-                for (obj, param) in objects.iter().zip_eq(signature.parameters.iter()) {
-                    ctx.set_object(namespace, param.name.clone(), obj.clone());
-                }
+                // let namespace = ctx.make_context();
+                // for (obj, param) in objects.iter().zip_eq(signature.parameters.iter()) {
+                //     ctx.set_object(namespace, param.name.clone(), obj.clone());
+                // }
 
-                let context = ctx.mir_contexts.get(context_id);
+                // let context = ctx.mir_contexts.get(context_id);
 
-                let llir_builder =
-                    LlirBuilder::new(context, ctx.namespaces, ctx.mir_contexts, ctx.llir_helper);
+                // let llir_builder =
+                //     LlirBuilder::new(context, ctx.namespaces, ctx.mir_contexts, ctx.llir_helper);
 
-                let return_value = llir_builder
-                    .build()
-                    .expect("ToDo make this error message compatible");
+                // let return_value = llir_builder
+                //     .build()
+                //     .expect("ToDo make this error message compatible");
 
-                // and finally call this function
-                let function_id = ctx.llir_helper.block_for((context.id, 0));
-                ctx.emit(Node::Call(Call { id: function_id }));
+                // // and finally call this function
+                // let function_id = ctx.llir_helper.block_for((context.id, 0));
+                // ctx.emit(Node::Call(Call { id: function_id }));
 
-                Ok(return_value)
+                // Ok(return_value)
+                let params = objects
+                    .iter()
+                    .zip_eq(signature.parameters.iter())
+                    .map(|(obj, param)| (obj.clone(), &param.name));
+                ctx.call(context_id, params)
             };
 
         let object_function = ObjFunction::new(

--- a/debris/core/src/objects/obj_native_function.rs
+++ b/debris/core/src/objects/obj_native_function.rs
@@ -69,33 +69,11 @@ impl ObjNativeFunction {
                 .map(|value| value.expected_type.clone())
                 .collect(),
         );
-        let function =
-            move |ctx: &mut FunctionContext, objects: &[ObjectRef]| -> LangResult<ObjectRef> {
-                // let namespace = ctx.make_context();
-                // for (obj, param) in objects.iter().zip_eq(signature.parameters.iter()) {
-                //     ctx.set_object(namespace, param.name.clone(), obj.clone());
-                // }
-
-                // let context = ctx.mir_contexts.get(context_id);
-
-                // let llir_builder =
-                //     LlirBuilder::new(context, ctx.namespaces, ctx.mir_contexts, ctx.llir_helper);
-
-                // let return_value = llir_builder
-                //     .build()
-                //     .expect("ToDo make this error message compatible");
-
-                // // and finally call this function
-                // let function_id = ctx.llir_helper.block_for((context.id, 0));
-                // ctx.emit(Node::Call(Call { id: function_id }));
-
-                // Ok(return_value)
-                let params = objects
-                    .iter()
-                    .zip_eq(signature.parameters.iter())
-                    .map(|(obj, param)| (obj.clone(), &param.name));
-                ctx.call(context_id, params)
-            };
+        let function = move |ctx: &mut FunctionContext, _: &[ObjectRef]| -> LangResult<ObjectRef> {
+            // The arguments may be ignored here, because the native function already
+            // gets evaluated in the mir for every call, thus all parameters are known
+            ctx.call(context_id)
+        };
 
         let object_function = ObjFunction::new(
             ctx,

--- a/debris/src/main.rs
+++ b/debris/src/main.rs
@@ -35,7 +35,7 @@ pub fn debug_run(compiler: &mut CompileConfig) -> Result<Llir> {
         contexts,
         mut namespaces,
     } = compiler.get_mir(&ast)?;
-    println!("{}", contexts);
+    // println!("{}", contexts);
     // println!("mir took {:?}", compile_time.elapsed());
 
     let llir = compiler.get_llir(&contexts, &mut namespaces)?;

--- a/debris/src/main.rs
+++ b/debris/src/main.rs
@@ -35,7 +35,7 @@ pub fn debug_run(compiler: &mut CompileConfig) -> Result<Llir> {
         contexts,
         mut namespaces,
     } = compiler.get_mir(&ast)?;
-    // println!("{}", contexts);
+    println!("{}", contexts);
     // println!("mir took {:?}", compile_time.elapsed());
 
     let llir = compiler.get_llir(&contexts, &mut namespaces)?;

--- a/debris/std/src/lib.rs
+++ b/debris/std/src/lib.rs
@@ -4,28 +4,7 @@
 //! There are not yet specific plans how it will look like.
 //!
 //! However, I plan to add at least a wrapper for every minecraft command.
-use debris_core::{
-    function_interface::{ToFunctionInterface, ValidReturnType},
-    llir::llir_nodes::ExecuteRaw,
-    llir::{
-        json_format::{FormattedText, JsonFormatComponent},
-        llir_nodes::{
-            ExecuteRawComponent, FastStore, FastStoreFromResult, Node, WriteMessage, WriteTarget,
-        },
-        utils::{Scoreboard, ScoreboardValue},
-    },
-    memory::copy,
-    objects::{
-        obj_bool::ObjBool,
-        obj_bool_static::ObjStaticBool,
-        obj_function::{FunctionContext, FunctionOverload, FunctionSignature, ObjFunction},
-        obj_int::ObjInt,
-        obj_int_static::ObjStaticInt,
-        obj_module::ObjModule,
-        obj_string::ObjString,
-    },
-    CompileContext, ObjectRef, ValidPayload,
-};
+use debris_core::{CompileContext, ObjectRef, ValidPayload, function_interface::{ToFunctionInterface, ValidReturnType}, llir::llir_nodes::ExecuteRaw, llir::{json_format::{FormattedText, JsonFormatComponent}, llir_nodes::{Call, ExecuteRawComponent, FastStore, FastStoreFromResult, Node, WriteMessage, WriteTarget}, utils::{Scoreboard, ScoreboardValue}}, memory::copy, objects::{obj_bool::ObjBool, obj_bool_static::ObjStaticBool, obj_call::ObjCall, obj_function::{FunctionContext, FunctionOverload, FunctionSignature, ObjFunction}, obj_int::ObjInt, obj_int_static::ObjStaticInt, obj_module::ObjModule, obj_string::ObjString}};
 
 fn signature_for<Params, Return, T>(ctx: &CompileContext, function: &'static T) -> FunctionOverload
 where
@@ -149,8 +128,10 @@ fn dbg_any(ctx: &mut FunctionContext, args: &[ObjectRef]) {
     ])));
 }
 
-fn register_ticking_function(_: &mut FunctionContext, function: &[ObjectRef]) {
+fn register_ticking_function(ctx: &mut FunctionContext, function: &ObjCall) {
     println!("Registered {:?}", function);
+    let id = ctx.block_for(function.context_id);
+    ctx.emit(Node::Call(Call {id}));
 }
 
 fn static_int_to_int(ctx: &mut FunctionContext, x: &ObjStaticInt) -> ObjInt {

--- a/debris/std/src/lib.rs
+++ b/debris/std/src/lib.rs
@@ -11,8 +11,7 @@ use debris_core::{
     llir::{
         json_format::{FormattedText, JsonFormatComponent},
         llir_nodes::{
-            ExecuteRawComponent, FastStore, FastStoreFromResult, Node, WriteMessage,
-            WriteTarget,
+            ExecuteRawComponent, FastStore, FastStoreFromResult, Node, WriteMessage, WriteTarget,
         },
         utils::{Scoreboard, ScoreboardValue},
     },

--- a/debris/tests/compile_tests.rs
+++ b/debris/tests/compile_tests.rs
@@ -56,14 +56,15 @@ fn test_compile_fails() {
         LangErrorKind::VariableAlreadyDefined { .. }
     );
 
-    expect_error!(
-        "unexpected_type_attribute_a.de",
-        LangErrorKind::UnexpectedType { .. }
-    );
-    expect_error!(
-        "unexpected_type_attribute_b.de",
-        LangErrorKind::UnexpectedType { .. }
-    );
+    // Type attributes are temporarily ignored
+    // expect_error!(
+    //     "unexpected_type_attribute_a.de",
+    //     LangErrorKind::UnexpectedType { .. }
+    // );
+    // expect_error!(
+    //     "unexpected_type_attribute_b.de",
+    //     LangErrorKind::UnexpectedType { .. }
+    // );
     expect_error!(
         "unexpected_type_function_a.de",
         LangErrorKind::UnexpectedType { .. }

--- a/debris/tests/datapack_tests.rs
+++ b/debris/tests/datapack_tests.rs
@@ -114,7 +114,7 @@ fn test_compiled_datapacks() {
 
     println!("Installing server");
     // The server needs to live until the end of the function
-    let server = ServerInstance::builder(&test_dir.0)
+    let mut server = ServerInstance::builder(&test_dir.0)
         .property("rcon.port", "25575")
         .property("rcon.password", "1234")
         .property("enable-rcon", "true")
@@ -152,7 +152,7 @@ fn test_compiled_datapacks() {
             .payload
             .split("test_result has ")
             .nth(1)
-            .expect("Bad server response")
+            .unwrap_or_else(|| panic!("Bad server response: {}", result.payload))
             .trim_end_matches(" [debris_test]")
             .parse()
             .expect("Could not parse score");
@@ -166,6 +166,8 @@ fn test_compiled_datapacks() {
             .expect("Could not remove previous datapack");
     }
 
-    // No need to gracefully shut it down since it will be deleted anyways
-    server.kill();
+    let result = server.try_stop();
+    if matches!(result, Err(_)) {
+        server.kill();
+    }
 }

--- a/examples/test.de
+++ b/examples/test.de
@@ -1,6 +1,9 @@
+let current_tick = 0;
 
 fn tick() {
+    current_tick = current_tick + 1;
     print("Ticking function");
+    print(current_tick);
 }
 
 register_ticking_function(tick);

--- a/examples/test.de
+++ b/examples/test.de
@@ -1,9 +1,20 @@
-let current_tick = 0;
+fn print_output(func: fn(Int, Int) -> Int) -> fn(Int, Int) -> Int {
+    fn wrapper(x: Int, y: Int) -> Int {
+        let result = func(x, y);
+        print(result);
+        result
+    }
 
-fn tick() {
-    current_tick = current_tick + 1;
-    print("Ticking function");
-    print(current_tick);
+    wrapper
 }
 
-register_ticking_function(tick);
+
+fn add(a: Int, b: Int) -> Int {
+    a + b
+}
+
+
+let wrapped_add = print_output(add);
+wrapped_add(5, 13);
+
+wrapped_add(dyn_int(5), dyn_int(13));


### PR DESCRIPTION
Initially this branch tried to improve functions. As it turned out that functions are more complicated than anticipated, this plan was changed and this branch was only used to clean up the existing function implementation a bit.